### PR TITLE
Replaced deprecated React class creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "browser-sync": "^2.26.5",
     "browserify": "16.2.3",
     "colors": "1.3.3",
+    "create-react-class": "^15.6.3",
     "del": "3.0.0",
     "dtslint": "0.1.2",
     "eslint": "4.19.1",
@@ -126,7 +127,5 @@
     "sequence",
     "iteration"
   ],
-  "dependencies": {
-    "create-react-class": "^15.6.3"
-  }
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -126,5 +126,7 @@
     "sequence",
     "iteration"
   ],
-  "dependencies": {}
+  "dependencies": {
+    "create-react-class": "^15.6.3"
+  }
 }

--- a/pages/src/src/Header.js
+++ b/pages/src/src/Header.js
@@ -10,12 +10,13 @@ var SVGSet = require('./SVGSet');
 var Logo = require('./Logo');
 var StarBtn = require('./StarBtn');
 var packageJson = require('../../../package.json');
+var createReactClass = require('create-react-class');
 
 var isMobileMatch =
   window.matchMedia && window.matchMedia('(max-device-width: 680px)');
 var isMobile = isMobileMatch && isMobileMatch.matches;
 
-var Header = React.createClass({
+var Header = createReactClass({
   getInitialState: function() {
     return { scroll: 0 };
   },

--- a/pages/src/src/Logo.js
+++ b/pages/src/src/Logo.js
@@ -6,8 +6,9 @@
  */
 
 var React = require('react');
+var createReactClass = require('create-react-class');
 
-var Logo = React.createClass({
+var Logo = React.createReactClass({
   shouldComponentUpdate: function(nextProps) {
     return nextProps.opacity !== this.props.opacity;
   },

--- a/pages/src/src/Logo.js
+++ b/pages/src/src/Logo.js
@@ -8,7 +8,7 @@
 var React = require('react');
 var createReactClass = require('create-react-class');
 
-var Logo = React.createReactClass({
+var Logo = createReactClass({
   shouldComponentUpdate: function(nextProps) {
     return nextProps.opacity !== this.props.opacity;
   },

--- a/pages/src/src/SVGSet.js
+++ b/pages/src/src/SVGSet.js
@@ -6,8 +6,9 @@
  */
 
 var React = require('react');
+var createReactClass = require('create-react-class');
 
-var SVGSet = React.createClass({
+var SVGSet = React.createReactClass({
   render: function() {
     return (
       <svg className="svg" style={this.props.style} viewBox="0 0 300 42.2">

--- a/pages/src/src/SVGSet.js
+++ b/pages/src/src/SVGSet.js
@@ -8,7 +8,7 @@
 var React = require('react');
 var createReactClass = require('create-react-class');
 
-var SVGSet = React.createReactClass({
+var SVGSet = createReactClass({
   render: function() {
     return (
       <svg className="svg" style={this.props.style} viewBox="0 0 300 42.2">

--- a/pages/src/src/StarBtn.js
+++ b/pages/src/src/StarBtn.js
@@ -12,7 +12,7 @@ var createReactClass = require('create-react-class');
 // https://registry.npmjs.org/immutable/latest
 // https://api.github.com/repos/facebook/immutable-js
 
-var StarBtn = React.createReactClass({
+var StarBtn = createReactClass({
   getInitialState: function() {
     return { stars: null };
   },

--- a/pages/src/src/StarBtn.js
+++ b/pages/src/src/StarBtn.js
@@ -7,12 +7,12 @@
 
 var React = require('react');
 var loadJSON = require('./loadJSON');
-
+var createReactClass = require('create-react-class');
 // API endpoints
 // https://registry.npmjs.org/immutable/latest
 // https://api.github.com/repos/facebook/immutable-js
 
-var StarBtn = React.createClass({
+var StarBtn = React.createReactClass({
   getInitialState: function() {
     return { stars: null };
   },

--- a/pages/src/src/index.js
+++ b/pages/src/src/index.js
@@ -12,7 +12,7 @@ var createReactClass = require('create-react-class');
 
 require('../../lib/runkit-embed');
 
-var Index = React.createReactClass({
+var Index = createReactClass({
   render: function() {
     return (
       <div>

--- a/pages/src/src/index.js
+++ b/pages/src/src/index.js
@@ -8,10 +8,11 @@
 var React = require('react');
 var Header = require('./Header');
 var readme = require('../../generated/readme.json');
+var createReactClass = require('create-react-class');
 
 require('../../lib/runkit-embed');
 
-var Index = React.createClass({
+var Index = React.createReactClass({
   render: function() {
     return (
       <div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1853,6 +1853,11 @@ copy-props@^2.0.1:
     each-props "^1.3.0"
     is-plain-object "^2.0.1"
 
+core-js@^1.0.0:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
+  integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
+
 core-js@^2.4.0, core-js@^2.5.0:
   version "2.6.5"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.5.tgz#44bc8d249e7fb2ff5d00e0341a7ffb94fbf67895"
@@ -1893,6 +1898,15 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     ripemd160 "^2.0.0"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+create-react-class@^15.6.3:
+  version "15.6.3"
+  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.3.tgz#2d73237fb3f970ae6ebe011a9e66f46dbca80036"
+  integrity sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
 
 cross-spawn@^5.1.0:
   version "5.1.0"
@@ -2342,6 +2356,13 @@ encodeurl@~1.0.1, encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
+
+encoding@^0.1.11:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
+  integrity sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=
+  dependencies:
+    iconv-lite "~0.4.13"
 
 end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   version "1.4.1"
@@ -2955,6 +2976,19 @@ fb-watchman@^2.0.0:
   integrity sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=
   dependencies:
     bser "^2.0.0"
+
+fbjs@^0.8.9:
+  version "0.8.17"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
+  integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.18"
 
 figures@^2.0.0:
   version "2.0.0"
@@ -3764,7 +3798,7 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
-iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.4, iconv-lite@^0.4.5:
+iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.4, iconv-lite@^0.4.5, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -4167,7 +4201,7 @@ is-resolvable@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
   integrity sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==
 
-is-stream@^1.1.0:
+is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
@@ -4247,6 +4281,14 @@ isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
+
+isomorphic-fetch@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
+  integrity sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=
+  dependencies:
+    node-fetch "^1.0.1"
+    whatwg-fetch ">=0.10.0"
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -5231,7 +5273,7 @@ longest@^1.0.1:
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
   integrity sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=
 
-loose-envify@^1.0.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -5687,6 +5729,14 @@ node-abi@^2.2.0:
   integrity sha512-1/aa2clS0pue0HjckL62CsbhWWU35HARvBDXcJtYKbYR7LnIutmpxmXbuDMV9kEviD2lP/wACOgWmmwljghHyQ==
   dependencies:
     semver "^5.4.1"
+
+node-fetch@^1.0.1:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
+  integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
+  dependencies:
+    encoding "^0.1.11"
+    is-stream "^1.0.1"
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -7331,6 +7381,11 @@ set-value@^2.0.0:
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
 
+setimmediate@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
+  integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
+
 setprototypeof@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.0.tgz#d0bd85536887b6fe7c0d818cb962d9d91c54e656"
@@ -8244,6 +8299,11 @@ ua-parser-js@0.7.17:
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"
   integrity sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g==
 
+ua-parser-js@^0.7.18:
+  version "0.7.19"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.19.tgz#94151be4c0a7fb1d001af7022fdaca4642659e4b"
+  integrity sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ==
+
 uglify-js@2.8.29, uglify-js@^2.8.22, uglify-js@~2.8.10:
   version "2.8.29"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
@@ -8588,6 +8648,11 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
   integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
   dependencies:
     iconv-lite "0.4.24"
+
+whatwg-fetch@>=0.10.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
+  integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
 
 whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0:
   version "2.3.0"


### PR DESCRIPTION
Fixed Error Prone: **React.createClass is deprecated since React 15.5.0, use the npm module create-react-class instead (react/no-deprecated)**
Related to #24