### PR TITLE
Use const instead of let, var when possible. 

### DIFF
--- a/type-definitions/ts-tests/covariance.ts
+++ b/type-definitions/ts-tests/covariance.ts
@@ -19,14 +19,14 @@ class B extends A { y: string; }
 class C { z: string; }
 
 // List covariance
-var listOfB: List<B> = List<B>();
+const listOfB: List<B> = List<B>();
 var listOfA: List<A> = listOfB;
 
 // $ExpectType List<B>
 listOfA = List([new B()]);
 
 // $ExpectError
-var listOfC: List<C> = listOfB;
+const listOfC: List<C> = listOfB;
 
 // Map covariance
 declare var mapOfB: Map<string, B>;
@@ -36,7 +36,7 @@ var mapOfA: Map<string, A> = mapOfB;
 mapOfA = Map({b: new B()});
 
 // $ExpectError
-var mapOfC: Map<string, C> = mapOfB;
+const mapOfC: Map<string, C> = mapOfB;
 
 // Set covariance
 declare var setOfB: Set<B>;
@@ -45,7 +45,7 @@ var setOfA: Set<A> = setOfB;
 // $ExpectType Set<B>
 setOfA = Set([new B()]);
 // $ExpectError
-var setOfC: Set<C> = setOfB;
+const setOfC: Set<C> = setOfB;
 
 // Stack covariance
 declare var stackOfB: Stack<B>;
@@ -53,7 +53,7 @@ var stackOfA: Stack<A> = stackOfB;
 // $ExpectType Stack<B>
 stackOfA = Stack([new B()]);
 // $ExpectError
-var stackOfC: Stack<C> = stackOfB;
+const stackOfC: Stack<C> = stackOfB;
 
 // OrderedMap covariance
 declare var orderedMapOfB: OrderedMap<string, B>;
@@ -61,7 +61,7 @@ var orderedMapOfA: OrderedMap<string, A> = orderedMapOfB;
 // $ExpectType OrderedMap<string, B>
 orderedMapOfA = OrderedMap({b: new B()});
 // $ExpectError
-var orderedMapOfC: OrderedMap<string, C> = orderedMapOfB;
+const orderedMapOfC: OrderedMap<string, C> = orderedMapOfB;
 
 // OrderedSet covariance
 declare var orderedSetOfB: OrderedSet<B>;
@@ -69,4 +69,4 @@ var orderedSetOfA: OrderedSet<A> = orderedSetOfB;
 // $ExpectType OrderedSet<B>
 orderedSetOfA = OrderedSet([new B()]);
 // $ExpectError
-var orderedSetOfC: OrderedSet<C> = orderedSetOfB;
+const orderedSetOfC: OrderedSet<C> = orderedSetOfB;

--- a/type-definitions/ts-tests/es6-collections.ts
+++ b/type-definitions/ts-tests/es6-collections.ts
@@ -11,15 +11,15 @@ import {
 } from '../../';
 
 // Immutable.js collections
-var mapImmutable: ImmutableMap<string, number> = ImmutableMap<string, number>();
-var setImmutable: ImmutableSet<string> = ImmutableSet<string>();
+const mapImmutable: ImmutableMap<string, number> = ImmutableMap<string, number>();
+const setImmutable: ImmutableSet<string> = ImmutableSet<string>();
 
 // $ExpectType Map<string, number>
 mapImmutable.delete('foo');
 
 // ES6 collections
-var mapES6: Map<string, number> = new Map<string, number>();
-var setES6: Set<string> = new Set<string>();
+const mapES6: Map<string, number> = new Map<string, number>();
+const setES6: Set<string> = new Set<string>();
 
 // $ExpectType boolean
 mapES6.delete('foo');


### PR DESCRIPTION
Fixed Error Prone: **Requires that variable declarations use `const` instead of `let` and `var` if possible.**
Related to #24 